### PR TITLE
added set data to card

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,6 +228,11 @@ function scrapeCard(url) {
         var $retreat = $stats.find(":contains(Retreat Cost)");
         card.retreatCost = $retreat.find(".energy").length;
 
+        card.set = {
+          name: $stats.find("h3").text(),
+          url: Url.resolve(SCRAPE_URL, $stats.find("h3 > a").attr("href"))
+        };
+
         return card;
     })();
 }


### PR DESCRIPTION
example:

[{
...other card info,
"set":{
  "name":"HS—Promo",
  "url":"http://www.pokemon.com/us/pokemon-tcg/pokemon-cards/?p-hs="
}},
...other cards
]

I would also like to somehow also crawl all the set data given the url of the set.